### PR TITLE
add Node Security Platform (NSP) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ node_js:
   - '0.10'
   - '4.4'
 sudo: false
+before_install:
+  - npm install -g nsp
 install: npm install
 services:
   - docker
 script:
+  - nsp check
   - npm run ci
   - >-
     bash <(curl

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.7.0",
-    "fh-mbaas-api": "5.5.6",
+    "fh-mbaas-api": "5.14.1",
     "q": "^1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Motivation:
To help identify/discover known vulnerabilities in this project.

Modifications:
Added nsp to the CI configuration (Travis).

Result:
nsp check will be run as part of CI

JIRA:
https://issues.jboss.org/browse/RAINCATCH-190
