### PR TITLE
remove travis nsp checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ node_js:
   - '0.10'
   - '4.4'
 sudo: false
-before_install:
-  - npm install -g nsp
 install: npm install
 services:
   - docker
 script:
-  - nsp check; exit 0
   - npm run ci
   - >-
     bash <(curl


### PR DESCRIPTION
**Motivation**
NSP was obsoleted by using snyk for checking vulnerabilities in dependencies. Currently the hack done for it to be an 'optional' check i.e. not fail builds is actually making CI builds that are supposed to fail pass.